### PR TITLE
BAXTER-22 - sha image is actually a signature and should not be removed

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.
-    # tags: [ 'v*.*.*' ]
+    tags: [ 'v*.*.*' ]
   # pull_request:
     # branches: [ "master" ]
 
@@ -78,8 +78,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   baxters_stuff:
     container_name: baxters_stuff
@@ -17,3 +15,4 @@ volumes:
 networks:
   default:
     name: baxternet
+    external: true


### PR DESCRIPTION
added back in commented out semver and removed github cache, added post-commit git hook for building and deploying local docker container